### PR TITLE
Update android buildToolsVersion to 33.0.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "33.0.0"
+        buildToolsVersion = "33.0.2"
         minSdkVersion = 21
         compileSdkVersion = 33
         targetSdkVersion = 33


### PR DESCRIPTION
ref: #16 
ref: https://linear.app/authgear/issue/DEV-1300/failed-to-build-android-app-due-to-zipalign-missing


Tested that buildToolsVersion to 33.0.2 can fix zipalign missing issue.
https://github.com/authgear/authgear-demo-app-rn/actions/runs/9065481381