### PR TITLE
Add iPad to supported destination

### DIFF
--- a/ios/AuthgearDemoAppRN.xcodeproj/project.pbxproj
+++ b/ios/AuthgearDemoAppRN.xcodeproj/project.pbxproj
@@ -577,8 +577,12 @@
 				PRODUCT_NAME = AuthgearDemoAppRN;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Authgear Demo React Native for sales Dev";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -609,7 +613,11 @@
 				PRODUCT_NAME = AuthgearDemoAppRN;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Authgear Demo React Native for sales";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;


### PR DESCRIPTION
ref: #10 
ref: https://linear.app/authgear/issue/DEV-1284/support-ipadtablet

iPad Pro


https://github.com/authgear/authgear-demo-app-rn/assets/19902333/a6ce1527-9b81-4a19-b62c-a036e2cbdf40

android tablet


https://github.com/authgear/authgear-demo-app-rn/assets/19902333/7e408e20-8f5e-404b-b885-6110e4cecf88



