### PR TITLE
Polish README, fix CI branch refs, add CLAUDE.md

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
         output_path: ./build/fastlane-api-key.json
     - run: make ios-build-app
     - run: make ios-upload-app
-      if: ${{ github.ref == 'refs/heads/master' }}
+      if: ${{ github.ref == 'refs/heads/main' }}
 
   react_native_android:
     if: ${{ github.repository == 'authgear/authgear-demo-app-rn' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
@@ -92,7 +92,7 @@ jobs:
         echo -n "$STORE_BASE64" | base64 --decode -o "$STORE_FILE"
         make build-aab
     - name: Upload aab
-      if: ${{ github.ref == 'refs/heads/master' }}
+      if: ${{ github.ref == 'refs/heads/main' }}
       env:
         GOOGLE_SERVICE_ACCOUNT_KEY_JSON_BASE64: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY_JSON_BASE64 }}
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A React Native (0.80.2, React 19, TypeScript) demo app that exercises the `@authgear/react-native` SDK. Its purpose is to demonstrate SDK features (login/logout, biometric auth, token storage modes, SSO, WeChat, WebView UI implementation), not to be a production app. The default config points at a public demo project (`https://demo-app.authgear.cloud`).
+
+## Commands
+
+The `Makefile` is the source of truth for CI checks — mirror it locally:
+
+```bash
+make npm-ci        # npm ci (clean install)
+make typecheck     # tsc --noEmit
+make check-format  # prettier --check on src/**
+make format        # prettier --write on src/**
+make lint          # eslint on .js,.jsx,.ts,.tsx
+make test          # jest
+```
+
+Run a single test: `npx jest src/placeholder.test.ts` (or `-t "<name>"` to filter by test name).
+
+Running the app:
+
+```bash
+npm start                          # Metro bundler
+npm run ios                        # build & run iOS (needs `cd ios && bundle exec pod install` first)
+npm run android                    # build & run Android
+```
+
+Toolchain versions are pinned in `.tool-versions` (Node 20.19.5, Ruby 3.3.7); `flake.nix` provisions Node/Ruby/Yarn but deliberately excludes the compiler so the Xcode-provided clang is used for iOS builds. CocoaPods and Fastlane run via Bundler (`bundle exec pod install`, `bundle exec fastlane ...`).
+
+## Architecture
+
+The app centers on the **`authgear` default container singleton** imported from `@authgear/react-native`. There is one shared instance; the two React context providers wrap it and expose its state to screens.
+
+- **`ConfigProvider`** (`src/context/ConfigProvider.tsx`) owns the `Config` object (client ID, endpoint, token-storage mode, SSO, WebView UI, biometric passcode fallback). On every config change it calls `authgear.configure(...)` and persists the config to `AsyncStorage`; on mount it rehydrates from `AsyncStorage`. Switching endpoints/token-storage re-configures the singleton. Read config via `useConfig()`.
+- **`UserProvider`** (`src/context/UserProvider.tsx`) tracks `sessionState` and `isBiometricEnabled`. It registers `authgear.delegate.onSessionStateChange` so session changes propagate into React state, and its `updateState(container)` is called after auth actions to refresh. Read via `useUser()`.
+- **`src/App.tsx`** wires the providers and a native-stack navigator (`Authentication` → `Configuration` / `UserPanel` / `UserInfo`; routes typed by `RootStackParamList`). It also holds app-wide constants and helpers that screens import directly: `redirectURI`, `wechatRedirectURI` (platform-selected), and **`getBiometricOptions(...)`** — the single place that maps the "enable biometric" and "allow passcode fallback" intents to platform-specific iOS `BiometricAccessConstraintIOS`/`BiometricLAPolicy` and Android authenticator flags. Change biometric behavior here, not in screens.
+
+Screens (`src/screens/`) call SDK methods on the `authgear` singleton directly (e.g. `authgear.authenticate`, `authgear.logout`, biometric enable/disable, `Page` open), then call `useUser().updateState(...)`. Errors are surfaced through `src/ShowError.tsx`.
+
+### Things that will bite you
+
+- **Container name per install** — `ConfigProvider` generates a random 44-char container name stored in `AsyncStorage` and assigns `authgear.name` before configuring. This is a deliberate workaround (issue #31): the anonymous-user key is tied to the container name, so a fixed name across endpoints causes invalid-credentials errors. Don't "simplify" this away.
+- **Theming is MD2** — uses `react-native-paper`'s `MD2LightTheme`/`MD2DarkTheme` merged with React Navigation themes, with custom color keys (`background`, `shadedBackground`). Screens type the theme as `MD2Theme` via `useTheme<MD2Theme>()`. Stay on MD2 APIs.
+- **Native redirect URIs** — `redirectURI` (`com.authgear.example.rn://host/path`) and the WeChat URIs must stay in sync with the native iOS/Android URL scheme configuration.
+
+## CI / deploy
+
+`.github/workflows/ci.yaml`: the `test` job runs the Makefile checks on every push/PR. iOS (Fastlane → TestFlight) and Android (Fastlane → Play Store) build jobs run only on the `authgear/authgear-demo-app-rn` repo. Store uploads are gated on the default branch. Fastlane lanes live in `fastlane/Fastfile` (`ios_build_app`, `ios_upload_app`, `build_aab`, `upload_aab`); build/version numbers are passed in as `date +%s`.
+
+Note: some workflow conditions still reference `refs/heads/master`; the default branch is now `main`, so those upload gates need updating to fire on `main`.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 # Authgear React Native Demo App
 
-This app is for demonstrating the usage of functions supportted by @authgear/react-native SDK.
+This app demonstrates the features supported by the [`@authgear/react-native`](https://www.npmjs.com/package/@authgear/react-native) SDK — including login/logout, biometric authentication, token storage modes, SSO, WeChat login, and the WebView UI implementation.
 
-# Initial setup
+The app ships pre-configured against a public demo project (`https://demo-app.authgear.cloud`). You can point it at your own Authgear project at runtime from the in-app **Configuration** screen (client ID, endpoint, token storage, and related options).
 
-## Environment Setup
+## Prerequisites
 
-Please read the environment setup guildlines by the official react-native team
+- Set up your machine for React Native development. See the official guide: [https://reactnative.dev/docs/environment-setup](https://reactnative.dev/docs/environment-setup)
+- Node.js and Ruby, at the versions pinned in [`.tool-versions`](./.tool-versions) (Node 20.19.5, Ruby 3.3.7). Ruby is required for CocoaPods and Fastlane.
 
-See [https://reactnative.dev/docs/environment-setup](https://reactnative.dev/docs/environment-setup)
+## Initial setup
 
-## Install dependencies
+### Install dependencies
 
 ```bash
 # In root of React Native demo app
 npm ci
+bundle install   # Ruby gems (CocoaPods, Fastlane), used for iOS builds
 ```
 
-## Start Metro server
+### Start Metro server
 
 ```bash
 # In root of React Native demo app
@@ -27,10 +29,10 @@ npm start
 ## Build Android app
 
 1. By command line
-    
+
     ```bash
     # In root of React Native demo app
-    npm run  android
+    npm run android
     ```
 
 2. By Android Studio
@@ -41,16 +43,16 @@ npm start
 
     iii. Click the `Run` button (play button)
 
-## Build IOS App
+## Build iOS app
 
 1. Install CocoaPods dependencies
 
     ```bash
     # In root of React Native demo app
-    cd ios && pod install && cd ..
+    cd ios && bundle exec pod install && cd ..
     ```
 
-    NOTE: make sure you enabled XCode command line tools (XCode Preference -> Location -> Command Line Tools)
+    NOTE: make sure you have enabled the Xcode command line tools (Xcode → Settings → Locations → Command Line Tools)
 
 2. Build by command line
 
@@ -61,6 +63,19 @@ npm start
 
 3. Build by Xcode
 
-    i. Configure `Signing and Capabilities` in XCode for signing the app
+    i. Configure `Signing & Capabilities` in Xcode for signing the app
 
-    ii. Click `Build` button in XCode (play button)
+    ii. Click the `Build` button in Xcode (play button)
+
+## Code quality checks
+
+These are the checks run in CI (see the [`Makefile`](./Makefile)):
+
+```bash
+make typecheck      # tsc --noEmit
+make check-format   # prettier --check
+make lint           # eslint
+make test           # jest
+```
+
+Run `make format` to auto-format sources with Prettier.


### PR DESCRIPTION
## Summary

Documentation and repo-hygiene cleanup, plus a follow-up to the `master` → `main` default-branch rename.

- **README**: fix typos (`supportted`, `guildlines`, `IOS`/`XCode`), correct the heading hierarchy, and switch the iOS setup to `bundle exec pod install` + a `bundle install` step to match this repo's Bundler-managed CocoaPods/Fastlane setup. Also adds a prerequisites section (pinned Node/Ruby from `.tool-versions`), an intro describing what the app demonstrates and the in-app Configuration screen, and a code-quality-checks section listing the Makefile targets CI runs.
- **ci.yaml**: update the iOS TestFlight and Android AAB upload gates from `refs/heads/master` to `refs/heads/main`. Without this, store uploads would no longer fire after the default branch was renamed to `main`.
- **CLAUDE.md**: add guidance for future contributors — build/lint/test commands and a high-level architecture overview (the shared `authgear` container singleton, the Config/User context providers, and a few non-obvious gotchas).

## Test plan

- `make typecheck && make check-format && make lint && make test` (no source code changed; docs/CI/markdown only).