### PR TITLE
Remove user-facing "Demo" references (DEV-1342)

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Authgear Demo</string>
+    <string name="app_name">Authgear Tools</string>
 </resources>

--- a/app.json
+++ b/app.json
@@ -1,4 +1,4 @@
 {
   "name": "AuthgearDemoAppRN",
-  "displayName": "Authgear Demo"
+  "displayName": "Authgear Tools"
 }

--- a/ios/AuthgearDemoAppRN/Info.plist
+++ b/ios/AuthgearDemoAppRN/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Authgear Demo</string>
+	<string>Authgear Tools</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ios/AuthgearDemoAppRN/LaunchScreen.storyboard
+++ b/ios/AuthgearDemoAppRN/LaunchScreen.storyboard
@@ -16,7 +16,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Authgear Demo" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Authgear" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
                                 <rect key="frame" x="0.0" y="202" width="375" height="43"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
                                 <nil key="highlightedColor"/>

--- a/src/screens/AuthenticationScreen.tsx
+++ b/src/screens/AuthenticationScreen.tsx
@@ -192,7 +192,7 @@ const AuthenticationScreen: React.FC<AuthenticationScreenProps> = (props) => {
         <LoadingSpinner loading={loading} />
         <View style={styles.headerContainer}>
           <View style={styles.titleContainer}>
-            <Text style={styles.titleText}>Authgear Demo</Text>
+            <Text style={styles.titleText}>Authgear</Text>
             <Text
               style={{ ...styles.subTitleText, color: theme.colors.disabled }}
             >

--- a/src/screens/ConfigurationScreen.tsx
+++ b/src/screens/ConfigurationScreen.tsx
@@ -241,7 +241,7 @@ const ConfigurationScreen: React.FC<ConfigurationScreenProps> = (props) => {
         style={styles.scrollView}
         contentContainerStyle={styles.contentContainer}
       >
-        <Text style={styles.titleText}>Authgear Demo</Text>
+        <Text style={styles.titleText}>Authgear</Text>
         <Text style={{ ...styles.subTitleText, color: theme.colors.disabled }}>
           Configuration
         </Text>

--- a/src/screens/UserPanelScreen.tsx
+++ b/src/screens/UserPanelScreen.tsx
@@ -329,7 +329,7 @@ const UserPanelScreen: React.FC<UserPanelScreenProps> = (props) => {
       <LoadingSpinner loading={loading} />
 
       <Appbar.Header>
-        <Appbar.Content title="Authgear Demo" />
+        <Appbar.Content title="Authgear" />
         <Appbar.Action
           icon="information-outline"
           onPress={() => setInfoDialogVisible(true)}


### PR DESCRIPTION
## Summary

The App Store rejects apps positioned for "demo" purposes (Guideline 2.2). This removes user-facing "Demo" branding per DEV-1342 / #32.

- **App display name → "Authgear Tools"**: `app.json` `displayName`, iOS `CFBundleDisplayName`, Android `app_name`.
- **In-app heading & top nav → "Authgear"**: Authentication + Configuration screen titles, UserPanel appbar, iOS launch-screen label.

## Left unchanged (intentionally)

Contain "Demo" but are not user-facing; changing them would break things:

- Internal RN module name `AuthgearDemoAppRN` (JS↔native bridge registration).
- Default endpoint `demo-app.authgear.cloud` (backend project, not branding).
- iOS provisioning-profile names in `ExportOptions.plist` / `project.pbxproj` (must match Apple Developer portal profiles).

## Follow-up

The deeper Guideline 2.2 fix — repositioning the app as an OIDC/OAuth integration tester (provider list + generic OIDC support) — lands in a separate PR. The 2.3.3 screenshot fix is an App Store Connect action, not code.

## Test plan

- `make typecheck && make check-format && make lint && make test` — all pass.

Closes #32