### PR TITLE
fix(android): bump compileSdk to 36 (androidx.browser via react-native-app-auth)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,10 @@
 buildscript {
     ext {
-        buildToolsVersion = "35.0.0"
+        buildToolsVersion = "36.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 35
+        // compileSdk 36 is required by androidx.browser:1.9.0, pulled in via
+        // react-native-app-auth. targetSdk stays at 35 (no behavior change).
+        compileSdkVersion = 36
         targetSdkVersion = 35
         // Use the 27.x NDK available on the GitHub runner image.
         // 27 is determined by the version of react-native.


### PR DESCRIPTION
## Problem
After #41 merged, the `react_native_android` CI job fails at `:app:checkReleaseAarMetadata`:

> Dependency `androidx.browser:browser:1.9.0` requires libraries and applications that depend on it to compile against version **36** or later of the Android APIs.

`react-native-app-auth` (added in #41) pulls in `androidx.browser:1.9.0`, which requires `compileSdk 36`; the app was on `compileSdk 35`.

## Fix
Bump `compileSdkVersion` and `buildToolsVersion` to **36** / **36.0.0** in `android/build.gradle`. `targetSdkVersion` stays at 35 (no runtime-behavior change).

## Verification
- `test` (typecheck/lint/format/jest) passes.
- The Android release build only runs on push to `main` (not on PRs, per `ci.yaml`), so the AAB build is verified by the post-merge CI run. iOS was already green on #41.